### PR TITLE
chore (package.json): allow react15 beside 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "autoprefixer-core": "^5.2.0",
     "babel": "^5.5.5",
     "babel-core": "^5.5.4",
-    "babel-eslint": "^3.1.14",
+    "babel-eslint": "^4.1.8",
     "babel-loader": "^5.1.4",
     "css-loader": "^0.14.4",
     "csswring": "^3.0.5",
@@ -39,6 +39,6 @@
     "webpack-dev-server": "^1.9.0"
   },
   "peerDependencies": {
-    "react": "^0.14.0"
+    "react": "^0.14.0 || ^15.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "autoprefixer-core": "^5.2.0",
     "babel": "^5.5.5",
     "babel-core": "^5.5.4",
-    "babel-eslint": "^4.1.8",
+    "babel-eslint": "^3.1.14",
     "babel-loader": "^5.1.4",
     "css-loader": "^0.14.4",
     "csswring": "^3.0.5",


### PR DESCRIPTION
React sticky box is very useful for us and we'd really like to use it in the future, but we need React 15 support if you don't mind.

Great job, sir! :)